### PR TITLE
Two code samples where the result can not be exploited by a XSS vuln

### DIFF
--- a/bin/XML/sanitize.xml
+++ b/bin/XML/sanitize.xml
@@ -435,7 +435,7 @@ else
       <safety flawType = "CWE_95_Injection" safe = "1" needQuote = "0" />
       <safety flawType = "CWE_98_Injection" safe = "1" needQuote = "0" />
       <safety flawType = "CWE_601_URF" safe = "1" needQuote = "0" urlSafe = "0"/>
-      <safety flawType = "CWE_79_XSS" doubleQuote = "1" scriptBlock = "1" styleBlock = "1" simpleQuote = "1" URL_CSS_context = "1" property_CSS_context = "1" rule1  = "1" />
+      <safety flawType = "CWE_79_XSS" safe = "1" needQuote="0" />
     </safeties>
     <safety safe = "1" needQuote = "0" />
   </sample>
@@ -1405,7 +1405,7 @@ else
       <safety flawType = "CWE_95_Injection" safe = "1" needQuote = "0" />
       <safety flawType = "CWE_98_Injection" safe = "1" needQuote = "0" />
       <safety flawType = "CWE_601_URF" safe = "1" needQuote = "0" urlSafe = "1"/>
-      <safety flawType = "CWE_79_XSS" simpleQuote = "1" />
+      <safety flawType = "CWE_79_XSS" safe = "1" simpleQuote = "1" />
       <safety flawType = "CWE_862_Fopen_IDOR" safe = "1"/>
       <safety flawType = "CWE_862_SQL_IDOR" safe = "1"/>
       <safety flawType = "CWE_862_XPath_IDOR" safe = "1"/>


### PR DESCRIPTION
Hello,

I think the generator is generating a couple of unsafe test cases that are actually safe. 

- The 'number_float_filter' code sample results in either a float or an empty string. I see no possibility to apply a XSS attack here.
- The 'ternary_white_list' code sample results in either the string 'safe1'  or 'safe2'. Both are defined by the developer, so I see no XSS attack here. 

Let me know if I need to adjust anything or if I'm missing something. 