### PR TITLE
Marking the sink as flaw instead of a random function

### DIFF
--- a/bin/Flaws_generators/Injection_Generator.py
+++ b/bin/Flaws_generators/Injection_Generator.py
@@ -135,8 +135,9 @@ class GeneratorInjection(Generator):
         if injection != "CWE_98":
             #Gets query execution code
             if not safe :
-                file.addContent("//flaw\n") #add this comment if not safe
-            footer = open("./execQuery_" + flawCwe[injection] + ".txt", "r")
+                footer = open("./execQuery_" + flawCwe[injection] + "_unsafe.txt", "r")
+            else:
+                footer = open("./execQuery_" + flawCwe[injection] + ".txt", "r")
             execQuery = footer.readlines()
             footer.close()
 

--- a/bin/execQuery_LDAP_unsafe.txt
+++ b/bin/execQuery_LDAP_unsafe.txt
@@ -1,0 +1,5 @@
+$ds=ldap_connect("localhost"); 
+$r=ldap_bind($ds);
+//flaw
+$sr=ldap_search($ds,"o=My Company, c=US", $query);  
+ldap_close($ds);

--- a/bin/execQuery_OSCommand_unsafe.txt
+++ b/bin/execQuery_OSCommand_unsafe.txt
@@ -1,0 +1,2 @@
+//flaw
+$ret = system($query);

--- a/bin/execQuery_SQL_unsafe.txt
+++ b/bin/execQuery_SQL_unsafe.txt
@@ -1,0 +1,12 @@
+$conn = mysql_connect('localhost', 'mysql_user', 'mysql_password'); // Connection to the database (address, user, password)
+mysql_select_db('dbname') ;
+echo "query : ". $query ."<br /><br />" ;
+
+//flaw
+$res = mysql_query($query); //execution
+
+while($data =mysql_fetch_array($res)){
+print_r($data) ;
+echo "<br />" ;
+} 
+mysql_close($conn);

--- a/bin/execQuery_XPath_unsafe.txt
+++ b/bin/execQuery_XPath_unsafe.txt
@@ -1,0 +1,7 @@
+$xml = simplexml_load_file("users.xml");//file load
+echo "query : ". $query ."<br /><br />" ;
+
+//flaw
+$res=$xml->xpath($query);//execution
+print_r($res);
+echo "<br />" ;

--- a/bin/execQuery_eval_unsafe.txt
+++ b/bin/execQuery_eval_unsafe.txt
@@ -1,0 +1,2 @@
+//flaw
+$res = eval($query);


### PR DESCRIPTION
Hello,

I've noticed that for the Injection test cases, the sink is not marked as the flaw but whatever function is the first line in the template. Source code analyzers generally mark the sink as where the vulnerability takes effect (exceptions notwithstanding), so I've made this change to better compare the performance of SCAs.
